### PR TITLE
add proper error responses

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,8 +43,8 @@ apply plugin: 'idea'
 apply plugin: 'application'
 
 group 'basalt'
-version '1.0'
-description = 'A high-performance, distributed audio node server based on Lavaplayer, Magma and the Vert.x Framework.'
+version '1.1.0'
+description = 'A high-performance, distributed audio node server based on Lavaplayer, Magma and Undertow.'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 mainClassName = 'basalt.MainKt'

--- a/docs/-basalt/alltypes/index.html
+++ b/docs/-basalt/alltypes/index.html
@@ -47,6 +47,13 @@ subsequently sent to Discord.</p>
 </tr>
 <tr>
 <td>
+<a href="../basalt.server/-error-responses/index.html">basalt.server.ErrorResponses</a></td>
+<td>
+<p>An enum of responses that are returned in Dispatched <code>ERROR</code> Responses, as they're written here.</p>
+</td>
+</tr>
+<tr>
+<td>
 <a href="../basalt.player/-load-result/index.html">basalt.player.LoadResult</a></td>
 <td>
 <p>A result class which represents a singular, successful load result.</p>

--- a/docs/-basalt/basalt.player/-basalt-player/on-player-pause.html
+++ b/docs/-basalt/basalt.player/-basalt-player/on-player-pause.html
@@ -11,7 +11,7 @@
 <a name="basalt.player.BasaltPlayer$onPlayerPause(com.sedmelluq.discord.lavaplayer.player.AudioPlayer)"></a>
 <code><span class="keyword">fun </span><span class="identifier">onPlayerPause</span><span class="symbol">(</span><span class="identifier" id="basalt.player.BasaltPlayer$onPlayerPause(com.sedmelluq.discord.lavaplayer.player.AudioPlayer)/player">player</span><span class="symbol">:</span>&nbsp;<span class="identifier">AudioPlayer</span><span class="symbol">)</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html"><span class="identifier">Unit</span></a></code>
 <p>Fired by Lavaplayer when the AudioPlayer is paused.</p>
-<p>This sends a <code>PLAYER_PAUSE</code> event, <strong>wrapped in a Dispatch Response</strong>, across a WebSocketChannel.
+<p>This sends a <code>PLAYER_PAUSED</code> event, <strong>wrapped in a Dispatch Response</strong>, across a WebSocketChannel.
 <strong>Note: This sends the same event as when the player is resumed, but the data is set to <code>true</code> (for "is paused").</strong></p>
 <h3>Parameters</h3>
 <p><a name="player"></a>

--- a/docs/-basalt/basalt.player/-basalt-player/on-player-resume.html
+++ b/docs/-basalt/basalt.player/-basalt-player/on-player-resume.html
@@ -11,7 +11,7 @@
 <a name="basalt.player.BasaltPlayer$onPlayerResume(com.sedmelluq.discord.lavaplayer.player.AudioPlayer)"></a>
 <code><span class="keyword">fun </span><span class="identifier">onPlayerResume</span><span class="symbol">(</span><span class="identifier" id="basalt.player.BasaltPlayer$onPlayerResume(com.sedmelluq.discord.lavaplayer.player.AudioPlayer)/player">player</span><span class="symbol">:</span>&nbsp;<span class="identifier">AudioPlayer</span><span class="symbol">)</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html"><span class="identifier">Unit</span></a></code>
 <p>Fired by Lavaplayer when the AudioPlayer is resumed.</p>
-<p>This sends a <code>PLAYER_PAUSE</code> event, <strong>wrapped in a Dispatch Response</strong>, across a WebSocketChannel.
+<p>This sends a <code>PLAYER_PAUSED</code> event, <strong>wrapped in a Dispatch Response</strong>, across a WebSocketChannel.
 <strong>Note: This sends the same event as when the player is paused, but the data is set to <code>false</code> (for "is paused").</strong></p>
 <h3>Parameters</h3>
 <p><a name="player"></a>

--- a/docs/-basalt/basalt.server/-error-responses/-n-o_-t-r-a-c-k.html
+++ b/docs/-basalt/basalt.server/-error-responses/-n-o_-t-r-a-c-k.html
@@ -1,0 +1,15 @@
+<HTML>
+<HEAD>
+<meta charset="UTF-8">
+<title>ErrorResponses.NO_TRACK - Basalt</title>
+<link rel="stylesheet" href="../../../style.css">
+</HEAD>
+<BODY>
+<a href="../../index.html">Basalt</a>&nbsp;/&nbsp;<a href="../index.html">basalt.server</a>&nbsp;/&nbsp;<a href="index.html">ErrorResponses</a>&nbsp;/&nbsp;<a href="./-n-o_-t-r-a-c-k.html">NO_TRACK</a><br/>
+<br/>
+<h1>NO_TRACK</h1>
+<a name="basalt.server.ErrorResponses.NO_TRACK"></a>
+<code><span class="identifier">NO_TRACK</span></code>
+<p>Returned if no track was playing upon an attempt to update it (i.e seeking).</p>
+</BODY>
+</HTML>

--- a/docs/-basalt/basalt.server/-error-responses/-p-l-a-y-e-r_-a-l-r-e-a-d-y_-i-n-i-t-i-a-l-i-z-e-d.html
+++ b/docs/-basalt/basalt.server/-error-responses/-p-l-a-y-e-r_-a-l-r-e-a-d-y_-i-n-i-t-i-a-l-i-z-e-d.html
@@ -1,0 +1,15 @@
+<HTML>
+<HEAD>
+<meta charset="UTF-8">
+<title>ErrorResponses.PLAYER_ALREADY_INITIALIZED - Basalt</title>
+<link rel="stylesheet" href="../../../style.css">
+</HEAD>
+<BODY>
+<a href="../../index.html">Basalt</a>&nbsp;/&nbsp;<a href="../index.html">basalt.server</a>&nbsp;/&nbsp;<a href="index.html">ErrorResponses</a>&nbsp;/&nbsp;<a href="./-p-l-a-y-e-r_-a-l-r-e-a-d-y_-i-n-i-t-i-a-l-i-z-e-d.html">PLAYER_ALREADY_INITIALIZED</a><br/>
+<br/>
+<h1>PLAYER_ALREADY_INITIALIZED</h1>
+<a name="basalt.server.ErrorResponses.PLAYER_ALREADY_INITIALIZED"></a>
+<code><span class="identifier">PLAYER_ALREADY_INITIALIZED</span></code>
+<p>Returned if an attempt was made to initialize an already-initialized player.</p>
+</BODY>
+</HTML>

--- a/docs/-basalt/basalt.server/-error-responses/-p-l-a-y-e-r_-a-l-r-e-a-d-y_-p-a-u-s-e-d.html
+++ b/docs/-basalt/basalt.server/-error-responses/-p-l-a-y-e-r_-a-l-r-e-a-d-y_-p-a-u-s-e-d.html
@@ -1,0 +1,15 @@
+<HTML>
+<HEAD>
+<meta charset="UTF-8">
+<title>ErrorResponses.PLAYER_ALREADY_PAUSED - Basalt</title>
+<link rel="stylesheet" href="../../../style.css">
+</HEAD>
+<BODY>
+<a href="../../index.html">Basalt</a>&nbsp;/&nbsp;<a href="../index.html">basalt.server</a>&nbsp;/&nbsp;<a href="index.html">ErrorResponses</a>&nbsp;/&nbsp;<a href="./-p-l-a-y-e-r_-a-l-r-e-a-d-y_-p-a-u-s-e-d.html">PLAYER_ALREADY_PAUSED</a><br/>
+<br/>
+<h1>PLAYER_ALREADY_PAUSED</h1>
+<a name="basalt.server.ErrorResponses.PLAYER_ALREADY_PAUSED"></a>
+<code><span class="identifier">PLAYER_ALREADY_PAUSED</span></code>
+<p>Returned if an attempt was made to pause a player if it is already paused.</p>
+</BODY>
+</HTML>

--- a/docs/-basalt/basalt.server/-error-responses/-p-l-a-y-e-r_-a-l-r-e-a-d-y_-r-e-s-u-m-e-d.html
+++ b/docs/-basalt/basalt.server/-error-responses/-p-l-a-y-e-r_-a-l-r-e-a-d-y_-r-e-s-u-m-e-d.html
@@ -1,0 +1,15 @@
+<HTML>
+<HEAD>
+<meta charset="UTF-8">
+<title>ErrorResponses.PLAYER_ALREADY_RESUMED - Basalt</title>
+<link rel="stylesheet" href="../../../style.css">
+</HEAD>
+<BODY>
+<a href="../../index.html">Basalt</a>&nbsp;/&nbsp;<a href="../index.html">basalt.server</a>&nbsp;/&nbsp;<a href="index.html">ErrorResponses</a>&nbsp;/&nbsp;<a href="./-p-l-a-y-e-r_-a-l-r-e-a-d-y_-r-e-s-u-m-e-d.html">PLAYER_ALREADY_RESUMED</a><br/>
+<br/>
+<h1>PLAYER_ALREADY_RESUMED</h1>
+<a name="basalt.server.ErrorResponses.PLAYER_ALREADY_RESUMED"></a>
+<code><span class="identifier">PLAYER_ALREADY_RESUMED</span></code>
+<p>Returned if an attempt was made to resume a player if it has already been resumed.</p>
+</BODY>
+</HTML>

--- a/docs/-basalt/basalt.server/-error-responses/-p-l-a-y-e-r_-n-o-t_-i-n-i-t-i-a-l-i-z-e-d.html
+++ b/docs/-basalt/basalt.server/-error-responses/-p-l-a-y-e-r_-n-o-t_-i-n-i-t-i-a-l-i-z-e-d.html
@@ -1,0 +1,15 @@
+<HTML>
+<HEAD>
+<meta charset="UTF-8">
+<title>ErrorResponses.PLAYER_NOT_INITIALIZED - Basalt</title>
+<link rel="stylesheet" href="../../../style.css">
+</HEAD>
+<BODY>
+<a href="../../index.html">Basalt</a>&nbsp;/&nbsp;<a href="../index.html">basalt.server</a>&nbsp;/&nbsp;<a href="index.html">ErrorResponses</a>&nbsp;/&nbsp;<a href="./-p-l-a-y-e-r_-n-o-t_-i-n-i-t-i-a-l-i-z-e-d.html">PLAYER_NOT_INITIALIZED</a><br/>
+<br/>
+<h1>PLAYER_NOT_INITIALIZED</h1>
+<a name="basalt.server.ErrorResponses.PLAYER_NOT_INITIALIZED"></a>
+<code><span class="identifier">PLAYER_NOT_INITIALIZED</span></code>
+<p>Returned if an attempt was made to update a non-existent player (before initializing).</p>
+</BODY>
+</HTML>

--- a/docs/-basalt/basalt.server/-error-responses/-p-o-s-i-t-i-o-n_-o-u-t_-o-f_-b-o-u-n-d-s.html
+++ b/docs/-basalt/basalt.server/-error-responses/-p-o-s-i-t-i-o-n_-o-u-t_-o-f_-b-o-u-n-d-s.html
@@ -1,0 +1,15 @@
+<HTML>
+<HEAD>
+<meta charset="UTF-8">
+<title>ErrorResponses.POSITION_OUT_OF_BOUNDS - Basalt</title>
+<link rel="stylesheet" href="../../../style.css">
+</HEAD>
+<BODY>
+<a href="../../index.html">Basalt</a>&nbsp;/&nbsp;<a href="../index.html">basalt.server</a>&nbsp;/&nbsp;<a href="index.html">ErrorResponses</a>&nbsp;/&nbsp;<a href="./-p-o-s-i-t-i-o-n_-o-u-t_-o-f_-b-o-u-n-d-s.html">POSITION_OUT_OF_BOUNDS</a><br/>
+<br/>
+<h1>POSITION_OUT_OF_BOUNDS</h1>
+<a name="basalt.server.ErrorResponses.POSITION_OUT_OF_BOUNDS"></a>
+<code><span class="identifier">POSITION_OUT_OF_BOUNDS</span></code>
+<p>Returned if an attempt was made to seek to a position below 0 or longer than the duration of the track.</p>
+</BODY>
+</HTML>

--- a/docs/-basalt/basalt.server/-error-responses/-t-r-a-c-k_-n-o-t_-s-e-e-k-a-b-l-e.html
+++ b/docs/-basalt/basalt.server/-error-responses/-t-r-a-c-k_-n-o-t_-s-e-e-k-a-b-l-e.html
@@ -1,0 +1,15 @@
+<HTML>
+<HEAD>
+<meta charset="UTF-8">
+<title>ErrorResponses.TRACK_NOT_SEEKABLE - Basalt</title>
+<link rel="stylesheet" href="../../../style.css">
+</HEAD>
+<BODY>
+<a href="../../index.html">Basalt</a>&nbsp;/&nbsp;<a href="../index.html">basalt.server</a>&nbsp;/&nbsp;<a href="index.html">ErrorResponses</a>&nbsp;/&nbsp;<a href="./-t-r-a-c-k_-n-o-t_-s-e-e-k-a-b-l-e.html">TRACK_NOT_SEEKABLE</a><br/>
+<br/>
+<h1>TRACK_NOT_SEEKABLE</h1>
+<a name="basalt.server.ErrorResponses.TRACK_NOT_SEEKABLE"></a>
+<code><span class="identifier">TRACK_NOT_SEEKABLE</span></code>
+<p>Returned if the currently playing track isn't seekable upon attempting to seek.</p>
+</BODY>
+</HTML>

--- a/docs/-basalt/basalt.server/-error-responses/-v-o-l-u-m-e_-o-u-t_-o-f_-b-o-u-n-d-s.html
+++ b/docs/-basalt/basalt.server/-error-responses/-v-o-l-u-m-e_-o-u-t_-o-f_-b-o-u-n-d-s.html
@@ -1,0 +1,15 @@
+<HTML>
+<HEAD>
+<meta charset="UTF-8">
+<title>ErrorResponses.VOLUME_OUT_OF_BOUNDS - Basalt</title>
+<link rel="stylesheet" href="../../../style.css">
+</HEAD>
+<BODY>
+<a href="../../index.html">Basalt</a>&nbsp;/&nbsp;<a href="../index.html">basalt.server</a>&nbsp;/&nbsp;<a href="index.html">ErrorResponses</a>&nbsp;/&nbsp;<a href="./-v-o-l-u-m-e_-o-u-t_-o-f_-b-o-u-n-d-s.html">VOLUME_OUT_OF_BOUNDS</a><br/>
+<br/>
+<h1>VOLUME_OUT_OF_BOUNDS</h1>
+<a name="basalt.server.ErrorResponses.VOLUME_OUT_OF_BOUNDS"></a>
+<code><span class="identifier">VOLUME_OUT_OF_BOUNDS</span></code>
+<p>Returned if an attempt was made to set the volume to below 0 or above 1000.</p>
+</BODY>
+</HTML>

--- a/docs/-basalt/basalt.server/-error-responses/index.html
+++ b/docs/-basalt/basalt.server/-error-responses/index.html
@@ -1,0 +1,90 @@
+<HTML>
+<HEAD>
+<meta charset="UTF-8">
+<title>ErrorResponses - Basalt</title>
+<link rel="stylesheet" href="../../../style.css">
+</HEAD>
+<BODY>
+<a href="../../index.html">Basalt</a>&nbsp;/&nbsp;<a href="../index.html">basalt.server</a>&nbsp;/&nbsp;<a href="./index.html">ErrorResponses</a><br/>
+<br/>
+<h1>ErrorResponses</h1>
+<code><span class="keyword">enum</span> <span class="keyword">class </span><span class="identifier">ErrorResponses</span></code>
+<p>An enum of responses that are returned in Dispatched <code>ERROR</code> Responses, as they're written here.</p>
+<p>This means that, for example, if you tried to set the volume of a player to -5, an <code>ERROR</code> event would be
+dispatched (as in wrapped in a Dispatch Response and sent back) in response with the value being
+"VOLUME_OUT_OF_BOUNDS".</p>
+<p><strong>Author</strong><br/>
+Sam Pritchard</p>
+<p><strong>Since</strong><br/>
+1.1.0</p>
+<h3>Enum Values</h3>
+<table>
+<tbody>
+<tr>
+<td>
+<p><a href="-n-o_-t-r-a-c-k.html">NO_TRACK</a></p>
+</td>
+<td>
+<p>Returned if no track was playing upon an attempt to update it (i.e seeking).</p>
+</td>
+</tr>
+<tr>
+<td>
+<p><a href="-t-r-a-c-k_-n-o-t_-s-e-e-k-a-b-l-e.html">TRACK_NOT_SEEKABLE</a></p>
+</td>
+<td>
+<p>Returned if the currently playing track isn't seekable upon attempting to seek.</p>
+</td>
+</tr>
+<tr>
+<td>
+<p><a href="-p-o-s-i-t-i-o-n_-o-u-t_-o-f_-b-o-u-n-d-s.html">POSITION_OUT_OF_BOUNDS</a></p>
+</td>
+<td>
+<p>Returned if an attempt was made to seek to a position below 0 or longer than the duration of the track.</p>
+</td>
+</tr>
+<tr>
+<td>
+<p><a href="-v-o-l-u-m-e_-o-u-t_-o-f_-b-o-u-n-d-s.html">VOLUME_OUT_OF_BOUNDS</a></p>
+</td>
+<td>
+<p>Returned if an attempt was made to set the volume to below 0 or above 1000.</p>
+</td>
+</tr>
+<tr>
+<td>
+<p><a href="-p-l-a-y-e-r_-n-o-t_-i-n-i-t-i-a-l-i-z-e-d.html">PLAYER_NOT_INITIALIZED</a></p>
+</td>
+<td>
+<p>Returned if an attempt was made to update a non-existent player (before initializing).</p>
+</td>
+</tr>
+<tr>
+<td>
+<p><a href="-p-l-a-y-e-r_-a-l-r-e-a-d-y_-i-n-i-t-i-a-l-i-z-e-d.html">PLAYER_ALREADY_INITIALIZED</a></p>
+</td>
+<td>
+<p>Returned if an attempt was made to initialize an already-initialized player.</p>
+</td>
+</tr>
+<tr>
+<td>
+<p><a href="-p-l-a-y-e-r_-a-l-r-e-a-d-y_-p-a-u-s-e-d.html">PLAYER_ALREADY_PAUSED</a></p>
+</td>
+<td>
+<p>Returned if an attempt was made to pause a player if it is already paused.</p>
+</td>
+</tr>
+<tr>
+<td>
+<p><a href="-p-l-a-y-e-r_-a-l-r-e-a-d-y_-r-e-s-u-m-e-d.html">PLAYER_ALREADY_RESUMED</a></p>
+</td>
+<td>
+<p>Returned if an attempt was made to resume a player if it has already been resumed.</p>
+</td>
+</tr>
+</tbody>
+</table>
+</BODY>
+</HTML>

--- a/docs/-basalt/basalt.server/index.html
+++ b/docs/-basalt/basalt.server/index.html
@@ -34,6 +34,15 @@ subsequently sent to Discord.</p>
 </tr>
 <tr>
 <td>
+<p><a href="-error-responses/index.html">ErrorResponses</a></p>
+</td>
+<td>
+<code><span class="keyword">enum</span> <span class="keyword">class </span><span class="identifier">ErrorResponses</span></code>
+<p>An enum of responses that are returned in Dispatched <code>ERROR</code> Responses, as they're written here.</p>
+</td>
+</tr>
+<tr>
+<td>
 <p><a href="-web-socket-listener/index.html">WebSocketListener</a></p>
 </td>
 <td>

--- a/docs/-basalt/index-outline.html
+++ b/docs/-basalt/index-outline.html
@@ -124,6 +124,26 @@
 </BODY>
 </HTML>
 </ul>
+<a href="/Users/Samuel/Documents/Basalt/build/docs/javadoc/-basalt/index"><a href="basalt.server/-error-responses/index.html"><span class="keyword">enum</span> <span class="keyword">class </span><span class="identifier">ErrorResponses</span></a></a><br/>
+<ul>
+<HTML>
+<HEAD>
+<meta charset="UTF-8">
+<title>Module Contents</title>
+<link rel="stylesheet" href="../style.css">
+</HEAD>
+<BODY>
+<a href="/Users/Samuel/Documents/Basalt/build/docs/javadoc/-basalt/index"><a href="basalt.server/-error-responses/-n-o_-t-r-a-c-k.html"><span class="identifier">NO_TRACK</span></a></a><br/>
+<a href="/Users/Samuel/Documents/Basalt/build/docs/javadoc/-basalt/index"><a href="basalt.server/-error-responses/-p-l-a-y-e-r_-a-l-r-e-a-d-y_-i-n-i-t-i-a-l-i-z-e-d.html"><span class="identifier">PLAYER_ALREADY_INITIALIZED</span></a></a><br/>
+<a href="/Users/Samuel/Documents/Basalt/build/docs/javadoc/-basalt/index"><a href="basalt.server/-error-responses/-p-l-a-y-e-r_-a-l-r-e-a-d-y_-p-a-u-s-e-d.html"><span class="identifier">PLAYER_ALREADY_PAUSED</span></a></a><br/>
+<a href="/Users/Samuel/Documents/Basalt/build/docs/javadoc/-basalt/index"><a href="basalt.server/-error-responses/-p-l-a-y-e-r_-a-l-r-e-a-d-y_-r-e-s-u-m-e-d.html"><span class="identifier">PLAYER_ALREADY_RESUMED</span></a></a><br/>
+<a href="/Users/Samuel/Documents/Basalt/build/docs/javadoc/-basalt/index"><a href="basalt.server/-error-responses/-p-l-a-y-e-r_-n-o-t_-i-n-i-t-i-a-l-i-z-e-d.html"><span class="identifier">PLAYER_NOT_INITIALIZED</span></a></a><br/>
+<a href="/Users/Samuel/Documents/Basalt/build/docs/javadoc/-basalt/index"><a href="basalt.server/-error-responses/-p-o-s-i-t-i-o-n_-o-u-t_-o-f_-b-o-u-n-d-s.html"><span class="identifier">POSITION_OUT_OF_BOUNDS</span></a></a><br/>
+<a href="/Users/Samuel/Documents/Basalt/build/docs/javadoc/-basalt/index"><a href="basalt.server/-error-responses/-t-r-a-c-k_-n-o-t_-s-e-e-k-a-b-l-e.html"><span class="identifier">TRACK_NOT_SEEKABLE</span></a></a><br/>
+<a href="/Users/Samuel/Documents/Basalt/build/docs/javadoc/-basalt/index"><a href="basalt.server/-error-responses/-v-o-l-u-m-e_-o-u-t_-o-f_-b-o-u-n-d-s.html"><span class="identifier">VOLUME_OUT_OF_BOUNDS</span></a></a><br/>
+</BODY>
+</HTML>
+</ul>
 <a href="/Users/Samuel/Documents/Basalt/build/docs/javadoc/-basalt/index"><a href="basalt.player/-load-result/index.html"><span class="keyword">class </span><span class="identifier">LoadResult</span></a></a><br/>
 <ul>
 <HTML>
@@ -365,6 +385,26 @@
 <a href="/Users/Samuel/Documents/Basalt/build/docs/javadoc/-basalt/index"><a href="basalt.server/-basalt-server/start.html"><span class="keyword">fun </span><span class="identifier">start</span><span class="symbol">(</span><span class="identifier" id="basalt.server.BasaltServer$start(io.vertx.core.Future((java.lang.Void)))/startFuture">startFuture</span><span class="symbol">:</span>&nbsp;<span class="identifier">Future</span><span class="symbol">&lt;</span><a href="http://docs.oracle.com/javase/8/docs/api/java/lang/Void.html"><span class="identifier">Void</span></a><span class="symbol">&gt;</span><span class="symbol">)</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html"><span class="identifier">Unit</span></a></a></a><br/>
 <a href="/Users/Samuel/Documents/Basalt/build/docs/javadoc/-basalt/index"><a href="basalt.server/-basalt-server/stop.html"><span class="keyword">fun </span><span class="identifier">stop</span><span class="symbol">(</span><span class="symbol">)</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html"><span class="identifier">Unit</span></a></a></a><br/>
 <a href="/Users/Samuel/Documents/Basalt/build/docs/javadoc/-basalt/index"><a href="basalt.server/-basalt-server/track-util.html"><span class="keyword">internal</span> <span class="keyword">val </span><span class="identifier">trackUtil</span><span class="symbol">: </span><a href="basalt.util/-audio-track-util/index.html"><span class="identifier">AudioTrackUtil</span></a></a></a><br/>
+</BODY>
+</HTML>
+</ul>
+<a href="/Users/Samuel/Documents/Basalt/build/docs/javadoc/-basalt/index"><a href="basalt.server/-error-responses/index.html"><span class="keyword">enum</span> <span class="keyword">class </span><span class="identifier">ErrorResponses</span></a></a><br/>
+<ul>
+<HTML>
+<HEAD>
+<meta charset="UTF-8">
+<title>Module Contents</title>
+<link rel="stylesheet" href="../style.css">
+</HEAD>
+<BODY>
+<a href="/Users/Samuel/Documents/Basalt/build/docs/javadoc/-basalt/index"><a href="basalt.server/-error-responses/-n-o_-t-r-a-c-k.html"><span class="identifier">NO_TRACK</span></a></a><br/>
+<a href="/Users/Samuel/Documents/Basalt/build/docs/javadoc/-basalt/index"><a href="basalt.server/-error-responses/-p-l-a-y-e-r_-a-l-r-e-a-d-y_-i-n-i-t-i-a-l-i-z-e-d.html"><span class="identifier">PLAYER_ALREADY_INITIALIZED</span></a></a><br/>
+<a href="/Users/Samuel/Documents/Basalt/build/docs/javadoc/-basalt/index"><a href="basalt.server/-error-responses/-p-l-a-y-e-r_-a-l-r-e-a-d-y_-p-a-u-s-e-d.html"><span class="identifier">PLAYER_ALREADY_PAUSED</span></a></a><br/>
+<a href="/Users/Samuel/Documents/Basalt/build/docs/javadoc/-basalt/index"><a href="basalt.server/-error-responses/-p-l-a-y-e-r_-a-l-r-e-a-d-y_-r-e-s-u-m-e-d.html"><span class="identifier">PLAYER_ALREADY_RESUMED</span></a></a><br/>
+<a href="/Users/Samuel/Documents/Basalt/build/docs/javadoc/-basalt/index"><a href="basalt.server/-error-responses/-p-l-a-y-e-r_-n-o-t_-i-n-i-t-i-a-l-i-z-e-d.html"><span class="identifier">PLAYER_NOT_INITIALIZED</span></a></a><br/>
+<a href="/Users/Samuel/Documents/Basalt/build/docs/javadoc/-basalt/index"><a href="basalt.server/-error-responses/-p-o-s-i-t-i-o-n_-o-u-t_-o-f_-b-o-u-n-d-s.html"><span class="identifier">POSITION_OUT_OF_BOUNDS</span></a></a><br/>
+<a href="/Users/Samuel/Documents/Basalt/build/docs/javadoc/-basalt/index"><a href="basalt.server/-error-responses/-t-r-a-c-k_-n-o-t_-s-e-e-k-a-b-l-e.html"><span class="identifier">TRACK_NOT_SEEKABLE</span></a></a><br/>
+<a href="/Users/Samuel/Documents/Basalt/build/docs/javadoc/-basalt/index"><a href="basalt.server/-error-responses/-v-o-l-u-m-e_-o-u-t_-o-f_-b-o-u-n-d-s.html"><span class="identifier">VOLUME_OUT_OF_BOUNDS</span></a></a><br/>
 </BODY>
 </HTML>
 </ul>

--- a/src/main/kotlin/basalt/messages/server/LoadTrackResponse.kt
+++ b/src/main/kotlin/basalt/messages/server/LoadTrackResponse.kt
@@ -21,7 +21,7 @@ import com.jsoniter.annotation.JsonIgnore
 @Suppress("UNUSED")
 class LoadTrackResponse internal constructor(@field:JsonIgnore private val result: LoadResult) {
     val playlistInfo = if (result.playlistInfo != null) PlaylistInfo() else null
-    val loadType = result.result
+    val loadType = result.result.name
     val tracks = result.tracks
     inner class PlaylistInfo {
         @JsonIgnore private val info = this@LoadTrackResponse.result.playlistInfo

--- a/src/main/kotlin/basalt/player/BasaltPlayer.kt
+++ b/src/main/kotlin/basalt/player/BasaltPlayer.kt
@@ -137,25 +137,25 @@ class BasaltPlayer internal constructor(internal val context: SocketContext, pri
     /**
      * Fired by Lavaplayer when the AudioPlayer is paused.
      *
-     * This sends a `PLAYER_PAUSE` event, **wrapped in a Dispatch Response**, across a WebSocketChannel.
+     * This sends a `PLAYER_PAUSED` event, **wrapped in a Dispatch Response**, across a WebSocketChannel.
      * **Note: This sends the same event as when the player is resumed, but the data is set to `true` (for "is paused").**
      *
      * @param player The AudioPlayer object itself.
      */
     override fun onPlayerPause(player: AudioPlayer) {
-        val response = DispatchResponse(context, guildId, "PLAYER_PAUSE", true)
+        val response = DispatchResponse(context, guildId, "PLAYER_PAUSED", true)
         WebSockets.sendText(JsonStream.serialize(response), context.channel, null)
     }
 
     /**
      * Fired by Lavaplayer when the AudioPlayer is resumed.
      *
-     * This sends a `PLAYER_PAUSE` event, **wrapped in a Dispatch Response**, across a WebSocketChannel.
+     * This sends a `PLAYER_PAUSED` event, **wrapped in a Dispatch Response**, across a WebSocketChannel.
      * **Note: This sends the same event as when the player is paused, but the data is set to `false` (for "is paused").**
      * @param player The AudioPlayer object itself.
      */
     override fun onPlayerResume(player: AudioPlayer) {
-        val response = DispatchResponse(context, guildId, "PLAYER_PAUSE", false)
+        val response = DispatchResponse(context, guildId, "PLAYER_PAUSED", false)
         WebSockets.sendText(JsonStream.serialize(response), context.channel, null)
     }
 }

--- a/src/main/kotlin/basalt/server/ErrorResponses.kt
+++ b/src/main/kotlin/basalt/server/ErrorResponses.kt
@@ -42,7 +42,5 @@ enum class ErrorResponses {
     /** Returned if an attempt was made to pause a player if it is already paused. */
     PLAYER_ALREADY_PAUSED,
     /** Returned if an attempt was made to resume a player if it has already been resumed. */
-    PLAYER_ALREADY_RESUMED,
-    /** Returned in an attempt was made to stop a player if it has already stopped. */
-    PLAYER_ALREADY_STOPPED
+    PLAYER_ALREADY_RESUMED
 }

--- a/src/main/kotlin/basalt/server/ErrorResponses.kt
+++ b/src/main/kotlin/basalt/server/ErrorResponses.kt
@@ -1,0 +1,27 @@
+package basalt.server
+
+/**
+ * An enum of responses that are returned in Dispatched `ERROR` Responses, as they're written here.
+ *
+ * This means that, for example, if you tried to set the volume of a player to -5, an `ERROR` event would be
+ * dispatched (as in wrapped in a Dispatch Response and sent back) in response with the value being
+ * "VOLUME_OUT_OF_BOUNDS".
+ *
+ * @author Sam Pritchard
+ * @since 1.1.0
+ */
+
+enum class ErrorResponses {
+    /** Returned if no track was playing upon an attempt to update it (i.e seeking). */
+    NO_TRACK,
+    /** Returned if the currently playing track isn't seekable upon attempting to seek. */
+    TRACK_NOT_SEEKABLE,
+    /** Returned if an attempt was made to seek to a position below 0 or longer than the duration of the track. */
+    POSITION_OUT_OF_BOUNDS,
+    /** Returned if an attempt was made to set the volume to below 0 or above 1000. */
+    VOLUME_OUT_OF_BOUNDS,
+    /** Returned if an attempt was made to update a non-existent player (before initializing). */
+    PLAYER_NOT_INITIALIZED,
+    /** Returned if an attempt was made to initialize an already-initialized player. */
+    PLAYER_ALREADY_INITIALIZED
+}

--- a/src/main/kotlin/basalt/server/ErrorResponses.kt
+++ b/src/main/kotlin/basalt/server/ErrorResponses.kt
@@ -1,3 +1,18 @@
+/*
+Copyright 2018 Sam Pritchard
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
 package basalt.server
 
 /**

--- a/src/main/kotlin/basalt/server/ErrorResponses.kt
+++ b/src/main/kotlin/basalt/server/ErrorResponses.kt
@@ -38,5 +38,11 @@ enum class ErrorResponses {
     /** Returned if an attempt was made to update a non-existent player (before initializing). */
     PLAYER_NOT_INITIALIZED,
     /** Returned if an attempt was made to initialize an already-initialized player. */
-    PLAYER_ALREADY_INITIALIZED
+    PLAYER_ALREADY_INITIALIZED,
+    /** Returned if an attempt was made to pause a player if it is already paused. */
+    PLAYER_ALREADY_PAUSED,
+    /** Returned if an attempt was made to resume a player if it has already been resumed. */
+    PLAYER_ALREADY_RESUMED,
+    /** Returned in an attempt was made to stop a player if it has already stopped. */
+    PLAYER_ALREADY_STOPPED
 }


### PR DESCRIPTION
in almost all cases (notable exception being the loading of tracks), basalt will now return constant `ERROR` payloads (wrapped in dispatch responses) in response to the following actions:

* no track playing when it should (`NO_TRACK`)
* track not seekable (`TRACK_NOT_SEEKABLE`)
* seek position out of bounds (`POSITION_OUT_OF_BOUNDS`)
* volume out of bounds (`VOLUME_OUT_OF_BOUNDS`)
* player not initialized when it should (`PLAYER_NOT_INITIALIZED`)
* player being initialized when it shouldn't (`PLAYER_ALREADY_INITIALIZED`)
* player already paused (`PLAYER_ALREADY_PAUSED`)
* player already resumed (`PLAYER_ALREADY_RESUMED`)